### PR TITLE
feat: Product, User, Cart, CartItem 엔티티 생성 및 연관관계 설정

### DIFF
--- a/src/main/java/com/mutsa/shoppingmall/ShoppingmallApplication.java
+++ b/src/main/java/com/mutsa/shoppingmall/ShoppingmallApplication.java
@@ -2,8 +2,10 @@ package com.mutsa.shoppingmall;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShoppingmallApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mutsa/shoppingmall/domain/Cart.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/Cart.java
@@ -1,0 +1,54 @@
+package com.mutsa.shoppingmall.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 장바구니(Cart) 엔티티
+ * - 사용자별 장바구니 1개 보유 (1:1)
+ */
+@Entity
+@Table(name = "carts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Cart {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 장바구니 소유 사용자 (1:1 관계) */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    /** 장바구니에 담긴 상품 목록 (1:N) */
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    /** 생성 일시 */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정 일시 */
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** 양방향 관계 설정을 위한 setter */
+    public void setUser(User user) {
+        this.user = user;
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/domain/CartItem.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/CartItem.java
@@ -1,0 +1,35 @@
+package com.mutsa.shoppingmall.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 장바구니 항목(CartItem) 엔티티
+ * - 특정 장바구니에 담긴 개별 상품 단위
+ * - 상품 + 수량 정보를 가짐
+ */
+@Entity
+@Table(name = "cart_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CartItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cartItemId;
+
+    /** 소속 장바구니 (N:1) */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    /** 담긴 상품 정보 (N:1) */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    /** 장바구니에 담긴 수량 */
+    private Integer quantity;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/domain/Product.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/Product.java
@@ -1,0 +1,57 @@
+package com.mutsa.shoppingmall.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 상품(Product) 엔티티
+ * - 판매 가능한 상품 정보
+ */
+@Entity
+@Table(name = "products")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 상품명 */
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    /** 상품 설명 */
+    @Column(length = 1000)
+    private String content;
+
+    /** 상품 가격 (단위: 원) */
+    @Column(nullable = false)
+    private Integer price;
+
+    /** 상품 이미지 URL */
+    @Column(length = 255)
+    private String imageUrl;
+
+    /** 재고 수량 */
+    @Column(nullable = false)
+    private Integer stockQuantity;
+
+    /** 생성 일시 */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정 일시 */
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/domain/User
+++ b/src/main/java/com/mutsa/shoppingmall/domain/User
@@ -1,0 +1,56 @@
+/**
+ * 회원(User) 엔티티
+ * - 로그인 사용자 정보
+ * - 장바구니와 1:1 연관
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 이메일 (로그인 ID 역할) */
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    /** 사용자 이름 */
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    /** 비밀번호 (암호화 저장 필수) */
+    @JsonIgnore
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    /** 사용자 장바구니 (1:1 관계, 역방향) */
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Cart cart;
+
+    /** 생성 일시 */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정 일시 */
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** 비밀번호 변경 메서드 */
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    /** 장바구니 할당 메서드 */
+    public void assignCart(Cart cart) {
+        this.cart = cart;
+        cart.setUser(this);
+    }
+}

--- a/src/main/java/com/mutsa/shoppingmall/domain/User.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/User.java
@@ -1,3 +1,15 @@
+package com.mutsa.shoppingmall.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+// import com.mutsa.shoppingmall.domain.cart.Cart;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
 /**
  * 회원(User) 엔티티
  * - 로그인 사용자 정보
@@ -30,8 +42,8 @@ public class User {
     private String password;
 
     /** 사용자 장바구니 (1:1 관계, 역방향) */
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private Cart cart;
+    // @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    // private Cart cart;
 
     /** 생성 일시 */
     @CreatedDate
@@ -48,9 +60,9 @@ public class User {
         this.password = encodedPassword;
     }
 
-    /** 장바구니 할당 메서드 */
-    public void assignCart(Cart cart) {
-        this.cart = cart;
-        cart.setUser(this);
-    }
+    // /** 장바구니 할당 메서드 */
+    // public void assignCart(Cart cart) {
+    //     this.cart = cart;
+    //     cart.setUser(this);
+    // }
 }

--- a/src/main/java/com/mutsa/shoppingmall/domain/User.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/User.java
@@ -42,8 +42,8 @@ public class User {
     private String password;
 
     /** 사용자 장바구니 (1:1 관계, 역방향) */
-    // @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    // private Cart cart;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Cart cart;
 
     /** 생성 일시 */
     @CreatedDate
@@ -60,9 +60,9 @@ public class User {
         this.password = encodedPassword;
     }
 
-    // /** 장바구니 할당 메서드 */
-    // public void assignCart(Cart cart) {
-    //     this.cart = cart;
-    //     cart.setUser(this);
-    // }
+    /** 장바구니 할당 메서드 */
+    public void assignCart(Cart cart) {
+        this.cart = cart;
+        cart.setUser(this);
+    }
 }


### PR DESCRIPTION
## 📦 목적
- 핵심 도메인인 Product, User, Cart, CartItem 엔티티를 정의하고 연관관계를 설계하기 위함

## 🔧 작업 내용
- Product 엔티티 생성
- User 엔티티 생성 및 Cart와 1:1 관계 설정
- Cart 엔티티 생성 및 CartItem과 1:N 관계 설정
- CartItem 엔티티 생성 및 Product, Cart와 N:1 관계 설정

## 📎 참고
- 연관관계 방향: CartItem 기준 단방향 설계
- 감사 필드는 User, Product, Cart에만 포함