### PR TITLE
feat: 장바구니 상품 추가 api 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,116 @@
+# 🛒 mutsa-shoppingmall
+
+Spring Boot 기반의 쇼핑몰 웹 서비스입니다.  
+멋쟁이사자처럼 Week 6 과제로 진행되며, 실무적인 구조와 Git Flow 브랜치 전략을 적용해 협업 중심으로 개발됩니다.
+
+---
+
+## 📌 프로젝트 개요
+
+- 상품 조회 및 검색
+- 장바구니 기능
+- 사용자 인증 예정
+- RESTful API 설계
+- DTO/Entity 분리 및 유효성 검증 적용 예정
+
+---
+
+## 👩‍💻 팀원
+
+| 이름     | 역할             |
+|----------|------------------|
+| 김다연   | 백엔드 개발자     |
+| 박서영   | 백엔드 개발자     |
+
+---
+
+## ⚙️ 기술 스택
+
+| 구분       | 기술                             |
+|------------|----------------------------------|
+| Language   | Java 21                          |
+| Framework  | Spring Boot 3.5.3                |
+| DB         | MySQL 8, H2 (test)               |
+| ORM        | Spring Data JPA                  |
+| Build Tool | Gradle                           |
+| 기타       | Lombok, JPA Auditing, Validation |
+
+---
+
+## 🧱 프로젝트 구조
+
+```
+
+src/
+└── main/
+├── java/com/mutsa/shoppingmall
+│   ├── domain        # Entity 및 도메인 로직
+│   ├── controller    # API 컨트롤러
+│   ├── service       # 서비스 계층
+│   ├── repository    # JPA 인터페이스
+│   ├── dto           # 요청/응답 DTO
+│   └── config        # 설정 클래스
+└── resources/
+├── application.properties
+
+````
+
+---
+
+## 🛠️ 실행 방법
+
+```bash
+# 1. 프로젝트 클론
+git clone https://github.com/danhandev/mutsa-shoppingmall.git
+
+# 2. 브랜치 이동
+git checkout develop
+
+# 3. MySQL 로컬 서버 실행 및 DB 생성
+create database shoppingmall;
+
+# 4. application.properties 설정 (DB 계정 입력)
+
+# 5. 프로젝트 실행
+./gradlew bootRun
+````
+
+---
+
+## 🔧 application.properties
+
+```properties
+spring.application.name=shoppingmall
+
+# MySQL Database Configuration
+spring.datasource.url=jdbc:mysql://localhost:3306/shoppingmall?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA Configuration
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Logging Configuration
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+```
+
+---
+
+## 🗂️ 브랜치 전략
+
+```plaintext
+main           → 실제 운영/배포 브랜치
+develop        → 모든 기능 개발의 기준 브랜치
+feature/기능명 → 기능 단위 개발 브랜치
+```
+
+* 모든 기능은 `feature/*`에서 개발 → `develop` 병합
+* 최종 릴리스는 `develop` → `main` 병합
+* PR은 GitHub에서 리뷰 후 병합
+
+---

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/mutsa/shoppingmall/ShoppingmallApplication.java
+++ b/src/main/java/com/mutsa/shoppingmall/ShoppingmallApplication.java
@@ -2,8 +2,10 @@ package com.mutsa.shoppingmall;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShoppingmallApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mutsa/shoppingmall/config/OpenApiConfig.java
+++ b/src/main/java/com/mutsa/shoppingmall/config/OpenApiConfig.java
@@ -1,0 +1,26 @@
+package com.mutsa.shoppingmall.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Swagger(OpenAPI) 기본 설정
+ */
+@Configuration
+public class OpenApiConfig {
+
+    /**
+     * OpenAPI 문서 기본 정보 설정
+     */
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Shopping Mall API")
+                        .description("쇼핑몰 프로젝트 API 명세서")
+                        .version("v1.0.0")
+                );
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/controller/CartController.java
+++ b/src/main/java/com/mutsa/shoppingmall/controller/CartController.java
@@ -2,6 +2,8 @@ package com.mutsa.shoppingmall.controller;
 
 import com.mutsa.shoppingmall.dto.CommonResponse;
 import com.mutsa.shoppingmall.dto.cart.CartResponse;
+import com.mutsa.shoppingmall.dto.cart.CartItemAddRequest;
+import com.mutsa.shoppingmall.dto.cart.CartItemAddResponse;
 import com.mutsa.shoppingmall.service.CartService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 /**
  * 장바구니 관련 API 컨트롤러
@@ -40,5 +45,30 @@ public class CartController {
                 .data(cartResponse)
                 .build()
         );
+    }
+
+    /**
+     * 장바구니에 상품 추가 API
+     * @param email 사용자 이메일
+     * @param request 상품ID, 수량
+     * @return 추가된 CartItem 정보
+     */
+    @Operation(summary = "장바구니 상품 추가", description = "장바구니에 상품을 추가합니다.",
+        responses = {
+            @ApiResponse(responseCode = "201", description = "장바구니에 상품을 추가했습니다.",
+                content = @Content(schema = @Schema(implementation = CartItemAddResponse.class)))
+        })
+    @PostMapping("/items")
+    public ResponseEntity<CommonResponse<CartItemAddResponse>> addCartItem(
+            @Parameter(description = "로그인한 사용자 이메일", required = true, example = "user@example.com")
+            @RequestParam String email,
+            @RequestBody CartItemAddRequest request) {
+        CartItemAddResponse response = cartService.addCartItem(email, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.<CartItemAddResponse>builder()
+                        .statusCode(HttpStatus.CREATED.value())
+                        .message("장바구니에 상품을 추가했습니다.")
+                        .data(response)
+                        .build());
     }
 } 

--- a/src/main/java/com/mutsa/shoppingmall/controller/CartController.java
+++ b/src/main/java/com/mutsa/shoppingmall/controller/CartController.java
@@ -1,0 +1,44 @@
+package com.mutsa.shoppingmall.controller;
+
+import com.mutsa.shoppingmall.dto.CommonResponse;
+import com.mutsa.shoppingmall.dto.cart.CartResponse;
+import com.mutsa.shoppingmall.service.CartService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 장바구니 관련 API 컨트롤러
+ */
+@Tag(name = "Cart", description = "장바구니 API")
+@RestController
+@RequestMapping("/api/v1/cart")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    /**
+     * 내 장바구니 조회 API
+     * @param email 로그인한 사용자 이메일 (실무에서는 인증 정보에서 추출)
+     * @return 장바구니 정보
+     */
+    @Operation(summary = "내 장바구니 조회", description = "로그인한 사용자의 장바구니 정보를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<CommonResponse<CartResponse>> getMyCart(
+            @Parameter(description = "로그인한 사용자 이메일", required = true, example = "user@example.com")
+            @RequestParam String email) {
+        CartResponse cartResponse = cartService.getMyCartByEmail(email);
+        return ResponseEntity.ok(
+            CommonResponse.<CartResponse>builder()
+                .statusCode(HttpStatus.OK.value())
+                .message("장바구니 조회를 성공했습니다.")
+                .data(cartResponse)
+                .build()
+        );
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/controller/CartController.java
+++ b/src/main/java/com/mutsa/shoppingmall/controller/CartController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 
 /**
  * 장바구니 관련 API 컨트롤러
@@ -62,7 +63,7 @@ public class CartController {
     public ResponseEntity<CommonResponse<CartItemAddResponse>> addCartItem(
             @Parameter(description = "로그인한 사용자 이메일", required = true, example = "user@example.com")
             @RequestParam String email,
-            @RequestBody CartItemAddRequest request) {
+            @Valid @RequestBody CartItemAddRequest request) {
         CartItemAddResponse response = cartService.addCartItem(email, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.<CartItemAddResponse>builder()

--- a/src/main/java/com/mutsa/shoppingmall/domain/Cart.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/Cart.java
@@ -1,0 +1,54 @@
+package com.mutsa.shoppingmall.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 장바구니(Cart) 엔티티
+ * - 사용자별 장바구니 1개 보유 (1:1)
+ */
+@Entity
+@Table(name = "carts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Cart {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 장바구니 소유 사용자 (1:1 관계) */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    /** 장바구니에 담긴 상품 목록 (1:N) */
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    /** 생성 일시 */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정 일시 */
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** 양방향 관계 설정을 위한 setter */
+    public void setUser(User user) {
+        this.user = user;
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/domain/CartItem.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/CartItem.java
@@ -1,0 +1,35 @@
+package com.mutsa.shoppingmall.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 장바구니 항목(CartItem) 엔티티
+ * - 특정 장바구니에 담긴 개별 상품 단위
+ * - 상품 + 수량 정보를 가짐
+ */
+@Entity
+@Table(name = "cart_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CartItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cartItemId;
+
+    /** 소속 장바구니 (N:1) */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    /** 담긴 상품 정보 (N:1) */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    /** 장바구니에 담긴 수량 */
+    private Integer quantity;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/domain/Product.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/Product.java
@@ -1,0 +1,57 @@
+package com.mutsa.shoppingmall.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 상품(Product) 엔티티
+ * - 판매 가능한 상품 정보
+ */
+@Entity
+@Table(name = "products")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 상품명 */
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    /** 상품 설명 */
+    @Column(length = 1000)
+    private String content;
+
+    /** 상품 가격 (단위: 원) */
+    @Column(nullable = false)
+    private Integer price;
+
+    /** 상품 이미지 URL */
+    @Column(length = 255)
+    private String imageUrl;
+
+    /** 재고 수량 */
+    @Column(nullable = false)
+    private Integer stockQuantity;
+
+    /** 생성 일시 */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정 일시 */
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/domain/User
+++ b/src/main/java/com/mutsa/shoppingmall/domain/User
@@ -1,0 +1,56 @@
+/**
+ * 회원(User) 엔티티
+ * - 로그인 사용자 정보
+ * - 장바구니와 1:1 연관
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 이메일 (로그인 ID 역할) */
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    /** 사용자 이름 */
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    /** 비밀번호 (암호화 저장 필수) */
+    @JsonIgnore
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    /** 사용자 장바구니 (1:1 관계, 역방향) */
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Cart cart;
+
+    /** 생성 일시 */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정 일시 */
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** 비밀번호 변경 메서드 */
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    /** 장바구니 할당 메서드 */
+    public void assignCart(Cart cart) {
+        this.cart = cart;
+        cart.setUser(this);
+    }
+}

--- a/src/main/java/com/mutsa/shoppingmall/domain/User.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/User.java
@@ -1,3 +1,15 @@
+package com.mutsa.shoppingmall.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+// import com.mutsa.shoppingmall.domain.cart.Cart;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
 /**
  * 회원(User) 엔티티
  * - 로그인 사용자 정보
@@ -30,8 +42,8 @@ public class User {
     private String password;
 
     /** 사용자 장바구니 (1:1 관계, 역방향) */
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private Cart cart;
+    // @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    // private Cart cart;
 
     /** 생성 일시 */
     @CreatedDate
@@ -48,9 +60,9 @@ public class User {
         this.password = encodedPassword;
     }
 
-    /** 장바구니 할당 메서드 */
-    public void assignCart(Cart cart) {
-        this.cart = cart;
-        cart.setUser(this);
-    }
+    // /** 장바구니 할당 메서드 */
+    // public void assignCart(Cart cart) {
+    //     this.cart = cart;
+    //     cart.setUser(this);
+    // }
 }

--- a/src/main/java/com/mutsa/shoppingmall/domain/User.java
+++ b/src/main/java/com/mutsa/shoppingmall/domain/User.java
@@ -42,8 +42,8 @@ public class User {
     private String password;
 
     /** 사용자 장바구니 (1:1 관계, 역방향) */
-    // @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    // private Cart cart;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Cart cart;
 
     /** 생성 일시 */
     @CreatedDate
@@ -60,9 +60,9 @@ public class User {
         this.password = encodedPassword;
     }
 
-    // /** 장바구니 할당 메서드 */
-    // public void assignCart(Cart cart) {
-    //     this.cart = cart;
-    //     cart.setUser(this);
-    // }
+    /** 장바구니 할당 메서드 */
+    public void assignCart(Cart cart) {
+        this.cart = cart;
+        cart.setUser(this);
+    }
 }

--- a/src/main/java/com/mutsa/shoppingmall/dto/CommonResponse.java
+++ b/src/main/java/com/mutsa/shoppingmall/dto/CommonResponse.java
@@ -1,0 +1,12 @@
+package com.mutsa.shoppingmall.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommonResponse<T> {
+    private int statusCode;
+    private String message;
+    private T data;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemAddRequest.java
+++ b/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemAddRequest.java
@@ -1,6 +1,8 @@
 package com.mutsa.shoppingmall.dto.cart;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 /**
@@ -8,9 +10,12 @@ import lombok.Getter;
  */
 @Getter
 public class CartItemAddRequest {
+    @NotNull(message = "상품 ID는 필수입니다.")
     @Schema(description = "추가할 상품 ID", example = "1", required = true)
     private Long productId;
 
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
     @Schema(description = "수량", example = "2", required = true)
     private Integer quantity;
 } 

--- a/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemAddRequest.java
+++ b/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemAddRequest.java
@@ -1,0 +1,16 @@
+package com.mutsa.shoppingmall.dto.cart;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+/**
+ * 장바구니 상품 추가 요청 DTO
+ */
+@Getter
+public class CartItemAddRequest {
+    @Schema(description = "추가할 상품 ID", example = "1", required = true)
+    private Long productId;
+
+    @Schema(description = "수량", example = "2", required = true)
+    private Integer quantity;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemAddResponse.java
+++ b/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemAddResponse.java
@@ -1,0 +1,21 @@
+package com.mutsa.shoppingmall.dto.cart;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 장바구니 상품 추가 응답 DTO
+ */
+@Getter
+@Builder
+public class CartItemAddResponse {
+    @Schema(description = "장바구니 항목 ID", example = "1")
+    private Long cartItemId;
+
+    @Schema(description = "상품 ID", example = "1")
+    private Long productId;
+
+    @Schema(description = "수량", example = "2")
+    private Integer quantity;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemResponse.java
+++ b/src/main/java/com/mutsa/shoppingmall/dto/cart/CartItemResponse.java
@@ -1,0 +1,18 @@
+package com.mutsa.shoppingmall.dto.cart;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 장바구니 항목(개별 상품) 응답 DTO
+ */
+@Getter
+@Builder
+public class CartItemResponse {
+    /** 장바구니 항목 ID */
+    private Long cartItemId;
+    /** 상품 정보 */
+    private ProductResponse product;
+    /** 담긴 수량 */
+    private Integer quantity;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/dto/cart/CartResponse.java
+++ b/src/main/java/com/mutsa/shoppingmall/dto/cart/CartResponse.java
@@ -1,0 +1,19 @@
+package com.mutsa.shoppingmall.dto.cart;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+/**
+ * 장바구니 전체 응답 DTO
+ */
+@Getter
+@Builder
+public class CartResponse {
+    /** 장바구니에 담긴 상품 목록 */
+    private List<CartItemResponse> cartItems;
+    /** 장바구니 전체 상품 개수 */
+    private Integer cartTotalItems;
+    /** 장바구니 전체 금액(원) */
+    private Integer cartTotalPrice;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/dto/cart/ProductResponse.java
+++ b/src/main/java/com/mutsa/shoppingmall/dto/cart/ProductResponse.java
@@ -1,0 +1,22 @@
+package com.mutsa.shoppingmall.dto.cart;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 장바구니 상품 정보 응답 DTO
+ */
+@Getter
+@Builder
+public class ProductResponse {
+    /** 상품 ID */
+    private Long id;
+    /** 상품명 */
+    private String name;
+    /** 상품 설명 */
+    private String content;
+    /** 상품 가격(원) */
+    private Integer price;
+    /** 상품 이미지 URL */
+    private String imageUrl;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/exception/BusinessException.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/BusinessException.java
@@ -1,0 +1,17 @@
+package com.mutsa.shoppingmall.exception;
+
+/**
+ * 비즈니스 예외의 최상위 클래스 (모든 커스텀 예외의 부모)
+ */
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/exception/CartNotFoundException.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/CartNotFoundException.java
@@ -1,0 +1,10 @@
+package com.mutsa.shoppingmall.exception;
+
+/**
+ * 장바구니가 존재하지 않을 때 발생하는 예외
+ */
+public class CartNotFoundException extends BusinessException {
+    public CartNotFoundException() {
+        super(ErrorCode.CART_NOT_FOUND);
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/exception/ErrorCode.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/ErrorCode.java
@@ -3,13 +3,14 @@ package com.mutsa.shoppingmall.exception;
 import org.springframework.http.HttpStatus;
 
 /**
- * API 공통 및 Cart 관련 에러 코드 정의
+ * API 공통 및 Cart/Product 관련 에러 코드 정의
  */
 public enum ErrorCode {
     // 공통 에러
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     UNAUTHORIZED("UNAUTHORIZED", "로그인 정보가 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_REQUEST("INVALID_REQUEST", "필수 항목이 누락되었습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST("INVALID_REQUEST", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    MISSING_REQUIRED_FIELD("MISSING_REQUIRED_FIELD", "필수 항목이 누락되었습니다.", HttpStatus.BAD_REQUEST),
     INVALID_TYPE("INVALID_TYPE", "입력 형식이 올바르지 않습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
 
     // Cart 관련 에러

--- a/src/main/java/com/mutsa/shoppingmall/exception/ErrorCode.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/ErrorCode.java
@@ -1,0 +1,44 @@
+package com.mutsa.shoppingmall.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * API 공통 및 Cart 관련 에러 코드 정의
+ */
+public enum ErrorCode {
+    // 공통 에러
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    UNAUTHORIZED("UNAUTHORIZED", "로그인 정보가 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REQUEST("INVALID_REQUEST", "필수 항목이 누락되었습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TYPE("INVALID_TYPE", "입력 형식이 올바르지 않습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+
+    // Cart 관련 에러
+    CART_NOT_FOUND("CART_NOT_FOUND", "장바구니가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    CART_ITEM_NOT_FOUND("CART_ITEM_NOT_FOUND", "해당 장바구니 상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
+    // Product 관련 에러
+    PRODUCT_NOT_FOUND("PRODUCT_NOT_FOUND", "해당 상품은 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getCode() {
+        return code;
+    }
+    public String getMessage() {
+        return message;
+    }
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    public int getStatus() {
+        return httpStatus.value();
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/exception/ErrorResponse.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.mutsa.shoppingmall.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * API 에러 응답 포맷 DTO
+ */
+@Getter
+@Builder
+public class ErrorResponse {
+    /** 에러 코드 */
+    private String errorCode;
+    /** 에러 메시지 */
+    private String message;
+    /** HTTP 상태 코드 */
+    private int status;
+    /** 에러 발생 시각 */
+    private LocalDateTime timestamp;
+    /** 요청 경로 */
+    private String path;
+} 

--- a/src/main/java/com/mutsa/shoppingmall/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package com.mutsa.shoppingmall.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+/**
+ * 전역 예외 처리기 (API 에러 응답 일원화)
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 비즈니스 예외 처리 (커스텀 예외)
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex, HttpServletRequest request) {
+        ErrorCode code = ex.getErrorCode();
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .errorCode(code.getCode())
+                .message(code.getMessage())
+                .status(code.getStatus())
+                .timestamp(LocalDateTime.now())
+                .path(request.getRequestURI())
+                .build();
+        return ResponseEntity.status(code.getStatus()).body(errorResponse);
+    }
+
+    /**
+     * 그 외 모든 예외 처리 (서버 에러)
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+        ErrorCode code = ErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .errorCode(code.getCode())
+                .message(code.getMessage())
+                .status(code.getStatus())
+                .timestamp(LocalDateTime.now())
+                .path(request.getRequestURI())
+                .build();
+        return ResponseEntity.status(code.getStatus()).body(errorResponse);
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/GlobalExceptionHandler.java
@@ -34,6 +34,10 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+        // springdoc-openapi 내부 요청은 기본 처리로 넘김
+        if (request.getRequestURI().startsWith("/v3/api-docs")) {
+            return null; // Spring 기본 처리로 넘김 (Swagger 정상 동작)
+        }
         ErrorCode code = ErrorCode.INTERNAL_SERVER_ERROR;
         ErrorResponse errorResponse = ErrorResponse.builder()
                 .errorCode(code.getCode())

--- a/src/main/java/com/mutsa/shoppingmall/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mutsa/shoppingmall/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.time.LocalDateTime;
 
@@ -42,6 +43,23 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.builder()
                 .errorCode(code.getCode())
                 .message(code.getMessage())
+                .status(code.getStatus())
+                .timestamp(LocalDateTime.now())
+                .path(request.getRequestURI())
+                .build();
+        return ResponseEntity.status(code.getStatus()).body(errorResponse);
+    }
+
+    /**
+     * 요청값 유효성 검증 실패 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        ErrorCode code = ErrorCode.MISSING_REQUIRED_FIELD;
+        String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .errorCode(code.getCode())
+                .message(message)
                 .status(code.getStatus())
                 .timestamp(LocalDateTime.now())
                 .path(request.getRequestURI())

--- a/src/main/java/com/mutsa/shoppingmall/repository/CartItemRepository.java
+++ b/src/main/java/com/mutsa/shoppingmall/repository/CartItemRepository.java
@@ -1,0 +1,7 @@
+package com.mutsa.shoppingmall.repository;
+
+import com.mutsa.shoppingmall.domain.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+} 

--- a/src/main/java/com/mutsa/shoppingmall/repository/CartRepository.java
+++ b/src/main/java/com/mutsa/shoppingmall/repository/CartRepository.java
@@ -2,9 +2,25 @@ package com.mutsa.shoppingmall.repository;
 
 import com.mutsa.shoppingmall.domain.Cart;
 import com.mutsa.shoppingmall.domain.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
+/**
+ * 장바구니(Cart) JPA Repository
+ */
 public interface CartRepository extends JpaRepository<Cart, Long> {
+    /**
+     * 사용자로 장바구니 조회 (cartItems, product fetch join)
+     */
+    @EntityGraph(attributePaths = {"cartItems", "cartItems.product"})
     Optional<Cart> findByUser(User user);
+
+    /**
+     * 사용자 이메일로 장바구니 fetch join 조회 (JPQL)
+     */
+    @Query("SELECT c FROM Cart c JOIN FETCH c.cartItems ci JOIN FETCH ci.product p WHERE c.user.email = :email")
+    Optional<Cart> findByUserEmailFetchJoin(@Param("email") String email);
 } 

--- a/src/main/java/com/mutsa/shoppingmall/repository/CartRepository.java
+++ b/src/main/java/com/mutsa/shoppingmall/repository/CartRepository.java
@@ -1,0 +1,10 @@
+package com.mutsa.shoppingmall.repository;
+
+import com.mutsa.shoppingmall.domain.Cart;
+import com.mutsa.shoppingmall.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    Optional<Cart> findByUser(User user);
+} 

--- a/src/main/java/com/mutsa/shoppingmall/repository/ProductRepository.java
+++ b/src/main/java/com/mutsa/shoppingmall/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.mutsa.shoppingmall.repository;
+
+import com.mutsa.shoppingmall.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+} 

--- a/src/main/java/com/mutsa/shoppingmall/repository/UserRepository.java
+++ b/src/main/java/com/mutsa/shoppingmall/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.mutsa.shoppingmall.repository;
+
+import com.mutsa.shoppingmall.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+} 

--- a/src/main/java/com/mutsa/shoppingmall/service/CartMapper.java
+++ b/src/main/java/com/mutsa/shoppingmall/service/CartMapper.java
@@ -4,6 +4,7 @@ import com.mutsa.shoppingmall.domain.Cart;
 import com.mutsa.shoppingmall.domain.CartItem;
 import com.mutsa.shoppingmall.dto.cart.CartItemResponse;
 import com.mutsa.shoppingmall.dto.cart.CartResponse;
+import com.mutsa.shoppingmall.dto.cart.CartItemAddResponse;
 import com.mutsa.shoppingmall.dto.cart.ProductResponse;
 import org.springframework.stereotype.Component;
 
@@ -47,6 +48,17 @@ public class CartMapper {
         return CartItemResponse.builder()
                 .cartItemId(cartItem.getCartItemId())
                 .product(toProductResponse(cartItem.getProduct()))
+                .quantity(cartItem.getQuantity())
+                .build();
+    }
+
+    /**
+     * CartItem 엔티티를 CartItemAddResponse DTO로 변환
+     */
+    public CartItemAddResponse toCartItemAddResponse(CartItem cartItem) {
+        return CartItemAddResponse.builder()
+                .cartItemId(cartItem.getCartItemId())
+                .productId(cartItem.getProduct().getId())
                 .quantity(cartItem.getQuantity())
                 .build();
     }

--- a/src/main/java/com/mutsa/shoppingmall/service/CartMapper.java
+++ b/src/main/java/com/mutsa/shoppingmall/service/CartMapper.java
@@ -1,0 +1,66 @@
+package com.mutsa.shoppingmall.service;
+
+import com.mutsa.shoppingmall.domain.Cart;
+import com.mutsa.shoppingmall.domain.CartItem;
+import com.mutsa.shoppingmall.dto.cart.CartItemResponse;
+import com.mutsa.shoppingmall.dto.cart.CartResponse;
+import com.mutsa.shoppingmall.dto.cart.ProductResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 장바구니 관련 엔티티 → DTO 변환 Mapper
+ */
+@Component
+public class CartMapper {
+    /**
+     * Cart 엔티티를 CartResponse DTO로 변환
+     * @param cart 장바구니 엔티티
+     * @return CartResponse DTO
+     */
+    public CartResponse toCartResponse(Cart cart) {
+        List<CartItemResponse> cartItems = cart.getCartItems().stream()
+                .map(this::toCartItemResponse)
+                .collect(Collectors.toList());
+
+        // cartTotalItems, cartTotalPrice를 한 번의 루프에서 계산
+        int cartTotalItems = 0;
+        int cartTotalPrice = 0;
+        for (CartItemResponse item : cartItems) {
+            cartTotalItems += item.getQuantity();
+            cartTotalPrice += item.getProduct().getPrice() * item.getQuantity();
+        }
+
+        return CartResponse.builder()
+                .cartItems(cartItems)
+                .cartTotalItems(cartTotalItems)
+                .cartTotalPrice(cartTotalPrice)
+                .build();
+    }
+
+    /**
+     * CartItem 엔티티를 CartItemResponse DTO로 변환
+     */
+    public CartItemResponse toCartItemResponse(CartItem cartItem) {
+        return CartItemResponse.builder()
+                .cartItemId(cartItem.getCartItemId())
+                .product(toProductResponse(cartItem.getProduct()))
+                .quantity(cartItem.getQuantity())
+                .build();
+    }
+
+    /**
+     * Product 엔티티를 ProductResponse DTO로 변환
+     */
+    public ProductResponse toProductResponse(com.mutsa.shoppingmall.domain.Product product) {
+        return ProductResponse.builder()
+                .id(product.getId())
+                .name(product.getName())
+                .content(product.getContent())
+                .price(product.getPrice())
+                .imageUrl(product.getImageUrl())
+                .build();
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/service/CartService.java
+++ b/src/main/java/com/mutsa/shoppingmall/service/CartService.java
@@ -1,0 +1,31 @@
+package com.mutsa.shoppingmall.service;
+
+import com.mutsa.shoppingmall.domain.Cart;
+import com.mutsa.shoppingmall.dto.cart.CartResponse;
+import com.mutsa.shoppingmall.repository.CartRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 장바구니 관련 비즈니스 로직 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final CartMapper cartMapper;
+
+    /**
+     * 내 장바구니 조회 (fetch join, Mapper 분리)
+     * @param email 로그인한 사용자 이메일
+     * @return 장바구니 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public CartResponse getMyCartByEmail(String email) {
+        Cart cart = cartRepository.findByUserEmailFetchJoin(email)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니가 존재하지 않습니다."));
+        return cartMapper.toCartResponse(cart);
+    }
+} 

--- a/src/main/java/com/mutsa/shoppingmall/service/CartService.java
+++ b/src/main/java/com/mutsa/shoppingmall/service/CartService.java
@@ -2,6 +2,7 @@ package com.mutsa.shoppingmall.service;
 
 import com.mutsa.shoppingmall.domain.Cart;
 import com.mutsa.shoppingmall.dto.cart.CartResponse;
+import com.mutsa.shoppingmall.exception.CartNotFoundException;
 import com.mutsa.shoppingmall.repository.CartRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,7 @@ public class CartService {
     @Transactional(readOnly = true)
     public CartResponse getMyCartByEmail(String email) {
         Cart cart = cartRepository.findByUserEmailFetchJoin(email)
-                .orElseThrow(() -> new IllegalArgumentException("장바구니가 존재하지 않습니다."));
+                .orElseThrow(CartNotFoundException::new);
         return cartMapper.toCartResponse(cart);
     }
 } 

--- a/src/main/java/com/mutsa/shoppingmall/service/CartService.java
+++ b/src/main/java/com/mutsa/shoppingmall/service/CartService.java
@@ -1,9 +1,17 @@
 package com.mutsa.shoppingmall.service;
 
 import com.mutsa.shoppingmall.domain.Cart;
+import com.mutsa.shoppingmall.domain.CartItem;
+import com.mutsa.shoppingmall.domain.Product;
 import com.mutsa.shoppingmall.dto.cart.CartResponse;
+import com.mutsa.shoppingmall.dto.cart.CartItemAddRequest;
+import com.mutsa.shoppingmall.dto.cart.CartItemAddResponse;
 import com.mutsa.shoppingmall.exception.CartNotFoundException;
+import com.mutsa.shoppingmall.exception.ErrorCode;
+import com.mutsa.shoppingmall.exception.BusinessException;
 import com.mutsa.shoppingmall.repository.CartRepository;
+import com.mutsa.shoppingmall.repository.CartItemRepository;
+import com.mutsa.shoppingmall.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +25,8 @@ public class CartService {
 
     private final CartRepository cartRepository;
     private final CartMapper cartMapper;
+    private final ProductRepository productRepository;
+    private final CartItemRepository cartItemRepository;
 
     /**
      * 내 장바구니 조회 (fetch join, Mapper 분리)
@@ -28,5 +38,27 @@ public class CartService {
         Cart cart = cartRepository.findByUserEmailFetchJoin(email)
                 .orElseThrow(CartNotFoundException::new);
         return cartMapper.toCartResponse(cart);
+    }
+
+    /**
+     * 장바구니에 상품 추가
+     * @param email 사용자 이메일
+     * @param request 상품ID, 수량
+     * @return 추가된 CartItem 정보
+     */
+    @Transactional
+    public CartItemAddResponse addCartItem(String email, CartItemAddRequest request) {
+        Cart cart = cartRepository.findByUserEmailFetchJoin(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+        // 이미 담긴 상품이어도 새로운 CartItem 생성
+        CartItem cartItem = CartItem.builder()
+                .cart(cart)
+                .product(product)
+                .quantity(request.getQuantity())
+                .build();
+        cartItemRepository.save(cartItem);
+        return cartMapper.toCartItemAddResponse(cartItem);
     }
 } 


### PR DESCRIPTION
## 📦 목적
- 장바구니에 상품을 추가하는 API(POST /api/v1/cart/items) 구현 및 관련 계층/예외/문서화 적용

---

## 🔧 작업 내용

- 장바구니 상품 추가 요청/응답 DTO(CartItemAddRequest, CartItemAddResponse) 생성
- CartService에 장바구니 상품 추가 비즈니스 로직 구현
- CartMapper에 CartItem → CartItemAddResponse 변환 메서드 추가
- CartController에 장바구니 상품 추가 API(POST /api/v1/cart/items) 엔드포인트 구현
- 요청값 유효성 검증(@NotNull, @Min 등) 및 @Valid 적용
- 전역 예외 처리기에서 MethodArgumentNotValidException 처리(에러 코드/메시지 일관화)
- Swagger 문서화 어노테이션 적용 및 API 명세 반영

---

## 🛠️ 기타 참고
- 성공 시 201 Created, 실패 시 실무 기준 에러 코드/메시지 반환
- 이미 담긴 상품 처리 정책: 항상 새 CartItem 추가(추후 정책 변경 가능)
- 실무 기준 주석 및 코드 스타일 적용

---

## 📎 참고
- 향후 장바구니 상품 삭제, 수량 변경, 중복 상품 처리 등 추가 기능 확장 예정